### PR TITLE
Resolve SettingsRepositoryInterface as late as possible

### DIFF
--- a/src/Listeners/SaveSettings.php
+++ b/src/Listeners/SaveSettings.php
@@ -2,23 +2,24 @@
 
 namespace Therealsujitk\GIFs\Listeners;
 
-use Flarum\Api\Serializer\UserSerializer;
+use Flarum\Api\Serializer\ForumSerializer;
 use Flarum\Api\Event\Serializing;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Events\Dispatcher;
 
-class SaveSettings {
-	protected $settings;
+class SaveSettings
+{
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Serializing::class, [$this, 'addAttributes']);
+    }
 
-	public function __construct(SettingsRepositoryInterface $settings) {
-		$this->settings = $settings;
-	}
+    public function addAttributes(Serializing $event)
+    {
+        if ($event->isSerializer(ForumSerializer::class)) {
+            $settings = app(SettingsRepositoryInterface::class);
 
-	public function subscribe(Dispatcher $events) {
-		$events->listen(Serializing::class, [$this, 'addAttributes']);
-	}
-
-	public function addAttributes(Serializing $event) {
-		$event->attributes['therealsujitk-gifs.giphy_api_key'] = $this->settings->get('therealsujitk-gifs.giphy_api_key');
-	}
+            $event->attributes['therealsujitk-gifs.giphy_api_key'] = $settings->get('therealsujitk-gifs.giphy_api_key');
+        }
+    }
 }


### PR DESCRIPTION
This gives the opportunity to other extensions to change its implementation.
Also added the missing check for ForumSerializer so that the value only gets added to the forum payload and not every other serialized payload.

This change would allow extenders like the one I provide in https://github.com/clarkwinkelmann/flarum-local-extenders#override-settings to override the setting value.

Let me know if you would have preferred I keep the original file formatting. My PhpStorm automatically formatted the file according to PSR-2.