### PR TITLE
fix: use assetsBaseUrl for powered-by image to support CDN installs

### DIFF
--- a/js/src/forum/components/GIFModal.js
+++ b/js/src/forum/components/GIFModal.js
@@ -20,7 +20,7 @@ export default class GIFModal extends Modal {
         super.oninit(vnode);
 
         this.textArea = this.attrs.textArea;
-        this.baseUrl = app.forum.attribute('baseUrl');
+        this.assetsBaseUrl = app.forum.attribute('assetsBaseUrl');
         this.engine = app.forum.attribute(`${prefix}.engine`) || 'giphy';
         this.apiKey = app.forum.attribute(`${prefix}.api_key`);
         this.rating = app.forum.attribute(`${prefix}.rating`) || 'off';
@@ -132,7 +132,7 @@ export default class GIFModal extends Modal {
 
                 <div id={`${prefix}-footer`}>
                     <img
-                        src={`${this.baseUrl}/assets/extensions/therealsujitk-gifs/powered_by_${this.engine}.svg`}
+                        src={`${this.assetsBaseUrl}/extensions/therealsujitk-gifs/powered_by_${this.engine}.svg`}
                     ></img>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- Replace `baseUrl` with `assetsBaseUrl` when building the path to the powered-by SVG image in the GIF modal
- Remove the now-redundant `/assets` path segment (since `assetsBaseUrl` already includes it)

## Why

On standard installs `baseUrl` and the assets location happen to coincide, so the image loads fine. However, when assets are hosted on a CDN or a separate domain (via `assetsBaseUrl` in Flarum's config), `baseUrl` still points to the forum root — causing the powered-by image path to be constructed incorrectly and the image to 404.